### PR TITLE
Cache FlexQuery reference in LocalStorage to avoid 1001 lockout

### DIFF
--- a/CapTrader.lua
+++ b/CapTrader.lua
@@ -3,7 +3,7 @@
 -- https://github.com/gering/MoneyMoney-CapTrader-Extension
 
 WebBanking {
-  version = 1.2,
+  version = 1.3,
   country = "de",
   services = { "CapTrader", "IBKR" },
   description = string.format(MM.localizeText("Get portfolio for %s"), "CapTrader")
@@ -19,6 +19,41 @@ local baseCurrencyOverride -- default is EUR
 -- Cache
 local cachedStatement
 local cachedFxRates = {} -- currency pair (e.g. EUR/USD) : rate
+
+-- Persistent reference cache. IBKR rate-limits FlexQuery generation harshly
+-- (sometimes for hours), so a successfully generated reference is reused
+-- across MoneyMoney syncs until it expires. Keyed by queryId so users with
+-- multiple CapTrader accounts on the same FlexQuery share one reference,
+-- but separate FlexQueries stay independent. A token fingerprint guards
+-- against silent reuse after the user rotates the token.
+local referenceTtl = 3600 -- 1 hour
+
+function tokenFingerprint()
+  return MM.sha256(token):sub(1, 16)
+end
+
+function loadCachedReference()
+  local ref       = LocalStorage["ref_"          .. queryId]
+  local expiresAt = LocalStorage["refExpiresAt_" .. queryId]
+  local tokenFp   = LocalStorage["refTokenFp_"   .. queryId]
+  if ref and tokenFp == tokenFingerprint() and expiresAt and os.time() < expiresAt then
+    print("Reusing cached FlexQuery reference (expires in " .. (expiresAt - os.time()) .. "s)")
+    return ref
+  end
+  return nil
+end
+
+function storeReference(ref)
+  LocalStorage["ref_"          .. queryId] = ref
+  LocalStorage["refExpiresAt_" .. queryId] = os.time() + referenceTtl
+  LocalStorage["refTokenFp_"   .. queryId] = tokenFingerprint()
+end
+
+function invalidateReference()
+  LocalStorage["ref_"          .. queryId] = nil
+  LocalStorage["refExpiresAt_" .. queryId] = nil
+  LocalStorage["refTokenFp_"   .. queryId] = nil
+end
 
 -- Extensions
 
@@ -53,20 +88,43 @@ function InitializeSession(protocol, bankCode, username, customer, password)
   queryId = username:match("[0-9]+")
   token = password
 
-  print("Requesting FlexQuery Reference")
-  local content = Connection():request("GET", "https://ndcdyn.interactivebrokers.com/Universal/servlet/FlexStatementService.SendRequest?t=" .. token .. "&q= " .. queryId .. "&v=3")
+  -- Reuse a previously generated reference if it's still fresh — avoids the
+  -- IBKR cooldown that triggers ErrorCode 1001 on the second sync of the day.
+  reference = loadCachedReference()
+  if reference then return end
 
-  -- Extract status and reference code
-  local status = content:parseTagContent("Status")
-  print("Status: " .. status)
+  -- No cached reference: generate one. A short retry handles transient 1001s,
+  -- but the longer (multi-hour) cooldowns IBKR seems to apply can't be ridden
+  -- out here — those are what the LocalStorage cache is for next time.
+  local maxAttempts = 3
+  for attempt = 1, maxAttempts do
+    print("Requesting FlexQuery Reference (attempt " .. attempt .. "/" .. maxAttempts .. ")")
+    local content = Connection():request("GET", "https://ndcdyn.interactivebrokers.com/Universal/servlet/FlexStatementService.SendRequest?t=" .. token .. "&q=" .. queryId .. "&v=3")
 
-  if status ~= "Success" then
+    local status = content:parseTagContent("Status")
+    print("Status: " .. status)
+
+    if status == "Success" then
+      reference = content:parseTagContent("ReferenceCode")
+      print("Reference: " .. reference)
+      storeReference(reference)
+      return
+    end
+
+    local errorCode = content:parseTagContent("ErrorCode")
     local errorMessage = content:parseTagContent("ErrorMessage")
-    error(errorMessage)
-    return LoginFailed
-  else
-    reference = content:parseTagContent("ReferenceCode")
-    print("Reference: " .. reference)
+    print("ErrorCode: " .. (errorCode or "?") .. " - " .. (errorMessage or ""))
+
+    -- 1001 is the only error worth retrying briefly. Everything else (bad
+    -- token, invalid query, ...) is permanent — fail immediately.
+    if errorCode ~= "1001" or attempt == maxAttempts then
+      error(errorMessage)
+      return LoginFailed
+    end
+
+    local delay = attempt * 5
+    print("Retrying in " .. delay .. "s")
+    MM.sleep(delay)
   end
 end
 
@@ -90,13 +148,40 @@ end
 -- Parsing FlexQuery
 
 function getStatement()
-  if cachedStatement == nil then
-    print("Fetching FlexQuery Statement")
-    MM.sleep(1) -- Sometimes the statement is not available immediately
-    cachedStatement = Connection():request("GET", "https://ndcdyn.interactivebrokers.com/Universal/servlet/FlexStatementService.GetStatement?t=" .. token .. "&q= " .. reference .. "&v=3")
+  if cachedStatement ~= nil then
+    return cachedStatement
   end
 
-  return cachedStatement
+  -- IBKR may still be generating the statement when we first ask. ErrorCode
+  -- 1019 ("Statement generation in progress") means "try again in a moment".
+  local maxAttempts = 10
+  for attempt = 1, maxAttempts do
+    print("Fetching FlexQuery Statement (attempt " .. attempt .. "/" .. maxAttempts .. ")")
+    MM.sleep(2)
+    local content = Connection():request("GET", "https://ndcdyn.interactivebrokers.com/Universal/servlet/FlexStatementService.GetStatement?t=" .. token .. "&q=" .. reference .. "&v=3")
+
+    -- A successful statement is wrapped in <FlexQueryResponse>; errors and
+    -- progress notifications come back as <FlexStatementResponse>.
+    if content:find("<FlexQueryResponse", 1, true) then
+      cachedStatement = content
+      return cachedStatement
+    end
+
+    local errorCode = content:parseTagContent("ErrorCode")
+    local errorMessage = content:parseTagContent("ErrorMessage")
+    print("ErrorCode: " .. (errorCode or "?") .. " - " .. (errorMessage or ""))
+
+    -- 1017 = reference code invalid (IBKR-side TTL on the statement expired
+    -- before our local TTL did). Drop the cache so the next sync generates
+    -- a fresh reference instead of repeating the same bad call.
+    if errorCode == "1017" then
+      invalidateReference()
+    end
+
+    if errorCode ~= "1019" or attempt == maxAttempts then
+      error(errorMessage)
+    end
+  end
 end
 
 function missingSectionError(sectionLabel)

--- a/CapTrader.lua
+++ b/CapTrader.lua
@@ -26,7 +26,12 @@ local cachedFxRates = {} -- currency pair (e.g. EUR/USD) : rate
 -- multiple CapTrader accounts on the same FlexQuery share one reference,
 -- but separate FlexQueries stay independent. A token fingerprint guards
 -- against silent reuse after the user rotates the token.
-local referenceTtl = 3600 -- 1 hour
+-- IBKR's per-(query, token) cooldown after a successful SendRequest lasts
+-- many hours (observed: still locked >2h later). Cache long enough to cover
+-- a typical workday so follow-up syncs reuse the reference instead of
+-- triggering another SendRequest. If IBKR expires the reference earlier,
+-- the 1017 handler in getStatement() invalidates the cache.
+local referenceTtl = 12 * 3600
 
 function tokenFingerprint()
   return MM.sha256(token):sub(1, 16)

--- a/CapTrader.lua
+++ b/CapTrader.lua
@@ -20,18 +20,11 @@ local baseCurrencyOverride -- default is EUR
 local cachedStatement
 local cachedFxRates = {} -- currency pair (e.g. EUR/USD) : rate
 
--- Persistent reference cache. IBKR rate-limits FlexQuery generation harshly
--- (sometimes for hours), so a successfully generated reference is reused
--- across MoneyMoney syncs until it expires. Keyed by queryId so users with
--- multiple CapTrader accounts on the same FlexQuery share one reference,
--- but separate FlexQueries stay independent. A token fingerprint guards
--- against silent reuse after the user rotates the token.
--- IBKR's per-(query, token) cooldown after a successful SendRequest lasts
--- many hours (observed: still locked >2h later). Cache long enough to cover
--- a typical workday so follow-up syncs reuse the reference instead of
--- triggering another SendRequest. If IBKR expires the reference earlier,
--- the 1017 handler in getStatement() invalidates the cache.
-local referenceTtl = 12 * 3600
+-- Persistent reference cache. IBKR's per-(query, token) cooldown after
+-- SendRequest can last many hours; reusing a still-valid reference avoids
+-- tripping ErrorCode 1001. The 1017 handler in getStatement() invalidates
+-- early if IBKR drops the reference before the local TTL.
+local referenceTtl = 12 * 3600 -- 12h, covers a typical workday
 
 function tokenFingerprint()
   return MM.sha256(token):sub(1, 16)
@@ -93,24 +86,22 @@ function InitializeSession(protocol, bankCode, username, customer, password)
   queryId = username:match("[0-9]+")
   token = password
 
-  -- Reuse a previously generated reference if it's still fresh — avoids the
-  -- IBKR cooldown that triggers ErrorCode 1001 on the second sync of the day.
   reference = loadCachedReference()
   if reference then return end
 
-  -- No cached reference: generate one. A short retry handles transient 1001s,
-  -- but the longer (multi-hour) cooldowns IBKR seems to apply can't be ridden
-  -- out here — those are what the LocalStorage cache is for next time.
   local maxAttempts = 3
   for attempt = 1, maxAttempts do
     print("Requesting FlexQuery Reference (attempt " .. attempt .. "/" .. maxAttempts .. ")")
     local content = Connection():request("GET", "https://ndcdyn.interactivebrokers.com/Universal/servlet/FlexStatementService.SendRequest?t=" .. token .. "&q=" .. queryId .. "&v=3")
 
     local status = content:parseTagContent("Status")
-    print("Status: " .. status)
+    print("Status: " .. (status or "?"))
 
     if status == "Success" then
       reference = content:parseTagContent("ReferenceCode")
+      if reference == nil or reference == "" then
+        error("FlexQuery returned Success without a ReferenceCode")
+      end
       print("Reference: " .. reference)
       storeReference(reference)
       return
@@ -120,11 +111,9 @@ function InitializeSession(protocol, bankCode, username, customer, password)
     local errorMessage = content:parseTagContent("ErrorMessage")
     print("ErrorCode: " .. (errorCode or "?") .. " - " .. (errorMessage or ""))
 
-    -- 1001 is the only error worth retrying briefly. Everything else (bad
-    -- token, invalid query, ...) is permanent — fail immediately.
+    -- Only 1001 is transient; all other error codes are permanent.
     if errorCode ~= "1001" or attempt == maxAttempts then
-      error(errorMessage)
-      return LoginFailed
+      error(errorMessage or ("FlexQuery SendRequest failed (ErrorCode " .. (errorCode or "unknown") .. ")"))
     end
 
     local delay = attempt * 5
@@ -157,17 +146,15 @@ function getStatement()
     return cachedStatement
   end
 
-  -- IBKR may still be generating the statement when we first ask. ErrorCode
-  -- 1019 ("Statement generation in progress") means "try again in a moment".
+  -- 1019 = statement still generating; poll until ready.
   local maxAttempts = 10
   for attempt = 1, maxAttempts do
     print("Fetching FlexQuery Statement (attempt " .. attempt .. "/" .. maxAttempts .. ")")
-    MM.sleep(2)
     local content = Connection():request("GET", "https://ndcdyn.interactivebrokers.com/Universal/servlet/FlexStatementService.GetStatement?t=" .. token .. "&q=" .. reference .. "&v=3")
 
     -- A successful statement is wrapped in <FlexQueryResponse>; errors and
     -- progress notifications come back as <FlexStatementResponse>.
-    if content:find("<FlexQueryResponse", 1, true) then
+    if type(content) == "string" and content:find("<FlexQueryResponse", 1, true) then
       cachedStatement = content
       return cachedStatement
     end
@@ -176,16 +163,16 @@ function getStatement()
     local errorMessage = content:parseTagContent("ErrorMessage")
     print("ErrorCode: " .. (errorCode or "?") .. " - " .. (errorMessage or ""))
 
-    -- 1017 = reference code invalid (IBKR-side TTL on the statement expired
-    -- before our local TTL did). Drop the cache so the next sync generates
-    -- a fresh reference instead of repeating the same bad call.
+    -- 1017 = reference invalid (IBKR TTL shorter than ours). Drop the cache.
     if errorCode == "1017" then
       invalidateReference()
     end
 
     if errorCode ~= "1019" or attempt == maxAttempts then
-      error(errorMessage)
+      error(errorMessage or ("FlexQuery GetStatement failed (ErrorCode " .. (errorCode or "unknown") .. ")"))
     end
+
+    MM.sleep(2)
   end
 end
 


### PR DESCRIPTION
Fixes #10.

## Problem

Since early May 2026, CapTrader syncs fail with `ErrorCode 1001 — Statement could not be generated at this time. Please try again shortly.`. The symptom: the very first sync of the day sometimes works, every subsequent sync within a few hours fails, often until the next day. "Refresh all accounts" reliably triggers the issue when multiple CapTrader accounts are configured, because MoneyMoney then fires several `SendRequest` calls within seconds of each other.

### Root Cause

The IBKR Flex Web Service enforces a cooldown after a successful statement generation for the same `(FlexQuery ID, Token)` pair. The official [v3 Error Codes documentation](https://www.ibkrguides.com/orgportal/performanceandstatements/flex3error.htm) describes `1001` as "transient" — without naming a cooldown duration — but the practical observation (combined with the fact that established Python clients like [`csingley/ibflex`](https://github.com/csingley/ibflex/blob/master/ibflex/client.py) don't even handle `1001`) suggests IBKR enforces these limits more aggressively than the docs imply. A related note from a [recent practical write-up](https://supa.is/article/interactive-brokers-flex-query-python-automate-reports-2026): "Activity Flex Queries contain data that is only updated once daily at close of business, so there is no benefit to generating and retrieving these reports more than once per day."

A simple retry with backoff does not help: a test with 100s of cumulative wait across 5 attempts still returns `1001` every time. The cooldown is significantly longer than that.

### Approach

Use the FlexQuery workflow as intended: `SendRequest` is the expensive, rate-limited operation; `GetStatement` is cheap and can be called repeatedly with a previously obtained `ReferenceCode`. Instead of generating a new statement on every sync, we cache the reference and reuse it until it expires.

## Changes

- **Persist the reference in `LocalStorage`** with expiry + token fingerprint, keyed by `queryId`:
  - Multiple MoneyMoney accounts on the **same** FlexQuery share one cache entry → only one `SendRequest` for the whole sync run.
  - Different FlexQueries get independent cache entries.
  - Token fingerprint (first 16 hex chars of `sha256(token)`) invalidates the cache when the user rotates the token.
- **TTL: 12 hours** (configurable via `referenceTtl`). The initial 1h proved too short: with IBKR's cooldown lasting many hours, a second sync after the TTL expired triggered a fresh `SendRequest` and hit `1001` again. 12h covers a typical workday.
- **IBKR-side cache invalidation**: `GetStatement` returning `ErrorCode 1017` (reference invalid) clears the local cache so the next sync regenerates cleanly.
- **Short retry on `1001`** still covers genuinely transient cases; longer IBKR cooldowns are now bypassed by serving the cached reference instead of retrying.
- **`GetStatement` polling**: the fixed `MM.sleep(1)` is replaced with a real poll loop that respects `ErrorCode 1019` ("generation in progress"). Sleep moved to the end of the loop so the first attempt (typical happy path on a cached reference) doesn't pay 2s latency.
- **Hardened error paths**: guard against `error(nil)` when IBKR responses lack `<ErrorMessage>`, fail loudly if `Status=Success` comes back without a `ReferenceCode`, type-check `GetStatement` response before string find.
- **URL typo**: dropped the stray space in `&q= ` for both endpoints.
- Version bumped to `1.3`. Signature removed (needs re-signing before release).

## Sources

- [IBKR Flex Web Service v3 Error Codes](https://www.ibkrguides.com/orgportal/performanceandstatements/flex3error.htm) — official docs for `1001`, `1017`, `1018`, `1019`.
- [`csingley/ibflex` – `client.py`](https://github.com/csingley/ibflex/blob/master/ibflex/client.py) — established Python client; handles only `1018` (10s) and `1019` (5s), `1001` is absent.
- [IB Flex Query + Python: Automate Trading Reports (2026)](https://supa.is/article/interactive-brokers-flex-query-python-automate-reports-2026) — practical write-up on current rate limits and daily-update behavior.
- [Flex Web Service – IBKR Campus](https://www.interactivebrokers.com/campus/ibkr-api-page/flex-web-service/) — IBKR API overview.
- [MoneyMoney WebBanking API – `LocalStorage`](https://moneymoney.app/api/webbanking/) — official docs for the persistent storage object.
- [`miracle2k/moneymoney-truelayer` – `TrueLayer.lua`](https://github.com/miracle2k/moneymoney-truelayer/blob/master/TrueLayer.lua) — reference implementation for the token-caching pattern with `LocalStorage`.

## Test plan

- [x] Initial sync without a cache: `SendRequest` runs, logs show `Reference: …`, statement is loaded.
- [x] Subsequent sync within 12h: logs show `Reusing cached FlexQuery reference (expires in …s)`, no `SendRequest`.
- [ ] Multi-account sync with two CapTrader accounts on the same FlexQuery: only one `SendRequest` in the logs overall. *(Cannot verify locally — single-account setup. Volker on #10 asked to validate.)*
- [x] Token rotation: next sync ignores the cache (fingerprint mismatch) and fetches a fresh reference.
- [x] TTL expiry (wait >12h or temporarily lower `referenceTtl`): next sync regenerates.
