### PR TITLE
Use IBKR's positionValue for correct bond and derivative pricing

### DIFF
--- a/CapTrader.lua
+++ b/CapTrader.lua
@@ -143,19 +143,26 @@ function parseAccountPositions(account)
     -- Update cache
     setFxRate(baseCurrencyOriginal, pos.currency, 1/pos.fxRateToBase)
 
+    -- IBKR provides the already-correct position value via `positionValue`.
+    -- For bonds, options, futures, and other non-equity instruments,
+    -- `markPrice * quantity` would be wrong (e.g. bond markPrice is a
+    -- percentage of nominal, not a per-unit price). Prefer the provided
+    -- value, fall back to the computed one if it's missing from the query.
+    local value = tonumber(pos.positionValue) or (pos.markPrice * quantity)
+
     mySecurities[#mySecurities+1] = {
       name = pos.symbol,
       isin = pos.isin,
       market = pos.listingExchange,
       quantity = quantity,
-      originalCurrencyAmount = pos.markPrice * quantity,
+      originalCurrencyAmount = value,
       currencyOfOriginalAmount = pos.currency,
       price = pos.markPrice,
       currencyOfPrice = pos.currency,
       purchasePrice = pos.costBasisMoney / pos.position,
       currencyOfPurchasePrice = pos.currency,
       exchangeRate = getFxRateToBase(pos.currency),
-      amount = convertToBase(pos.markPrice * quantity, pos.currency)
+      amount = convertToBase(value, pos.currency)
     }
   end
 


### PR DESCRIPTION
Fixes #6.

## Problem

For bonds and other non-equity instruments, the previous valuation
`markPrice * position * multiplier` is wrong. Bonds quote `markPrice` as a percentage of nominal value (e.g. `99.99` = 99.99 %), not as a per-unit price. A single bond with nominal 1000 and mark price 99.99 % was reported as **99,990 €** instead of the correct **999.90 €** — a factor 100 too high (see @maltetgh's screenshots in #6).

The same shape of bug exists in principle for any instrument where IBKR's `markPrice` semantics deviate from "price per unit" — options and futures with unusual multipliers, for example.

## Approach

IBKR's `OpenPosition` element already exposes an attribute `positionValue` that holds the correct value in the position's currency, computed by IBKR for whichever asset class. Read it directly instead of reconstructing the math on our side.

```lua
local value = tonumber(pos.positionValue) or (pos.markPrice * quantity)
```

The `or` keeps a safe fallback for users whose FlexQuery configuration doesn't include `positionValue`. `tonumber()` makes sure a missing/blank attribute correctly triggers the fallback (an explicit `"0"` stays numeric zero — that's intentional, a position genuinely worth zero shouldn't fall back to a computed mark-price guess).

`price` and `quantity` remain as before — for bonds, MoneyMoney will then display the price as e.g. `99.99` (which is the correct % notation), and `value = quantity * price / 100` is implicit via `positionValue`.


## Test plan

- [ ] Verify equity positions still show identical values (sanity check that `positionValue` matches our old computation for standard stocks).
- [ ] Verify a bond position now reports the correct value, matching the CapTrader/IBKR depot view.
- [ ] Verify positions still load if a user's FlexQuery doesn't include `positionValue` (fallback path).
