### PR TITLE
Surface missing FlexQuery sections with a helpful error

### DIFF
--- a/CapTrader.lua
+++ b/CapTrader.lua
@@ -99,8 +99,16 @@ function getStatement()
   return cachedStatement
 end
 
+function missingSectionError(sectionLabel)
+  error(string.format(
+    MM.localizeText("FlexQuery section '%s' is missing. Please enable it in the CapTrader FlexQuery configuration."),
+    sectionLabel))
+end
+
 function parseAccountInfo()
-  local accountInfo = getStatement():parseTag("AccountInformation"):parseArgs()
+  local tag = getStatement():parseTag("AccountInformation")
+  if tag == nil then missingSectionError("Account Information") end
+  local accountInfo = tag:parseArgs()
   baseCurrencyOriginal = accountInfo.currency
 
   print("Account base currency: " .. baseCurrencyOriginal)
@@ -122,6 +130,7 @@ end
 
 function parseAccountPositions(account)
   local openPositions = getStatement():parseTagContent("OpenPositions")
+  if openPositions == nil then missingSectionError("Open Positions") end
   local mySecurities = {}
 
   -- Parse open positions
@@ -155,6 +164,7 @@ end
 
 function parseAccountBalances(account)
   local cashReports = getStatement():parseTagContent("CashReport")
+  if cashReports == nil then missingSectionError("Cash Report") end
   local myBalances = {}
   local hasForexPositions = false
 
@@ -299,4 +309,3 @@ function setFxRate(base, quote, rate)
   end
 end
 
--- SIGNATURE: MCwCFEQG7Gns2hW/DGF8OWhVRTd6Wa/hAhQqSVw2/zvIc5t+DbEJvnVdXDdQpA==

--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,36 @@
+<!-- Diese Datei bei Änderungen mit README.md synchron halten. -->
+[Lesen Sie dies auf Englisch](README.md)
+
+# MoneyMoney-CapTrader-Erweiterung
+Inoffizielle CapTrader-Erweiterung für MoneyMoney. Ruft Salden von CapTrader ab und gibt sie als Wertpapiere zurück.
+
+## Einrichtung
+
+Aktivieren Sie den Flex-Web-Service in den Einstellungen Ihres CapTrader-Kontos und erzeugen Sie einen `Token`. Dieser Token ist Ihr Passwort.
+Zusätzlich wird eine Flex-Query-ID als Benutzername benötigt. Am einfachsten konfigurieren Sie die Drittanbieterdienste und aktivieren **Yodlee**. Verwenden Sie dann die `Query-ID` von **Yodlee** als Benutzernamen.
+
+In MoneyMoney eintragen:
+- Benutzername: `Query-ID`, z. B. 0123456
+- Passwort: `Token`, z. B. 123456789012345678
+
+## Basiswährung festlegen
+
+Standardmäßig verwendet diese Erweiterung EUR als Basiswährung. MoneyMoney zeigt also in EUR an, auch wenn Ihr CapTrader-Konto auf USD eingestellt ist. Falls Ihr CapTrader-Konto eine andere Basiswährung wie USD verwendet und Sie Ihre Wertpapiere ebenfalls in USD anzeigen möchten, können Sie die Basiswährung überschreiben. Hängen Sie dazu einfach die Währung an die `Query-ID` an:
+
+- Benutzername: `Query-ID/Währung`, z. B. 0123456/USD
+- Passwort: `Token`, z. B. 123456789012345678
+
+## Erforderliche Flex-Query-Sections
+
+Wenn Sie eine eigene Flex-Query erstellen (statt **Yodlee** zu verwenden), müssen darin folgende Sections enthalten sein, sonst kann MoneyMoney Ihr Depot nicht laden:
+
+- **Account Information** (erforderlich)
+- **Open Positions** (erforderlich)
+- **Cash Report** (erforderlich)
+- **Conversion Rates** (optional — siehe unten)
+
+Sie finden diese Einstellungen in CapTrader unter Reports → Flex Queries → Ihre Query → **Sections**.
+
+## Währungsumrechnung
+
+Wenn Sie die Basiswährung überschreiben oder die Währung in MoneyMoney von der des CapTrader-Kontos abweicht, sollten Sie in Ihrer eigenen Flex-Query **Conversion Rates** aktivieren. Ohne diese Section bezieht die Erweiterung die Wechselkurse bei Bedarf von der EZB; diese können geringfügig von den CapTrader-Kursen abweichen.

--- a/README.md
+++ b/README.md
@@ -17,5 +17,17 @@ This Plugin uses EUR as default base currency. This means MoneyMoney will displa
 - Username: `Query-ID/Currency` e.g. 0123456/USD
 - Password: `Token` e.g. 123456789012345678
 
-**Note:** If you override the base currency, or your curreny of MoneyMoney differs from the CapTrader account, then you may want to create a custom Flex-Query, where you enable conversion rates. Ensure you add `account information`, `cash reports` and `open positions` to your custom Flex-Query.
-If you do not enable conversion rates, then this plugin fetches conversion rates when needed, but they may differ from those of your Flex-Queries.
+## Required Flex-Query sections
+
+If you create a custom Flex-Query (instead of using **Yodlee**), it must include the following sections, otherwise MoneyMoney will fail to load your portfolio:
+
+- **Account Information** (required)
+- **Open Positions** (required)
+- **Cash Report** (required)
+- **Conversion Rates** (optional — see below)
+
+You can find these settings in CapTrader → Reports → Flex Queries → your query → **Sections**.
+
+## Base currency conversion
+
+If you override the base currency, or the currency of MoneyMoney differs from the CapTrader account, then you may want to enable **Conversion Rates** in your custom Flex-Query. Without it the plugin fetches FX rates from the ECB when needed, but those may differ slightly from CapTrader's.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+<!-- Keep this file in sync with README.de.md when making changes. -->
+[Read this in German](README.de.md)
+
 # MoneyMoney-CapTrader-Extension
 Unofficial CapTrader Extension for MoneyMoney. Fetches balances from CapTrader and returns them as securities.
 


### PR DESCRIPTION
Fixes #9.

## Problem

If a user's custom FlexQuery doesn't include one of the sections the plugin reads, parsing crashes with `CapTrader.lua:NNN: attempt to index a nil value` (line numbers vary by file revision) and no hint about the actual cause.

Three sections are required and crash in their respective parse function when missing:

| Section | Parse function | Symptom on `main` |
|---|---|---|
| `AccountInformation` | `parseAccountInfo` | `nil:parseArgs()` crash |
| `OpenPositions` | `parseAccountPositions` | `nil:parseTags(...)` crash |
| `CashReport` | `parseAccountBalances` | `nil:parseTags(...)` crash |

`ConversionRates` is optional and already handled gracefully — this PR aligns the other three with that pattern but with an explicit, localized error message instead of a silent skip (these sections actually are required for the plugin to function).

## Changes

- `CapTrader.lua`: add a `missingSectionError` helper that raises a localized error naming the missing section, and call it from each of the three parse functions before the first dereference. Existing happy path is unchanged.
- `README.md`: promote the previously buried hint about required sections into its own **Required Flex-Query sections** heading with a clear bullet list and a pointer to where the setting lives in CapTrader's UI. Conversion Rates moves into its own section since it's optional.

## Test plan

- [x] Existing working setups load identically — no behavior change on the happy path.
- [x] A FlexQuery missing `AccountInformation`, `OpenPositions`, or `CashReport` now produces a readable error in MoneyMoney instead of a Lua crash.


## Follow-up: German README

While we're touching the docs anyway, this PR also adds a `README.de.md` and cross-links the two language versions on the first line — matching the convention used in `MoneyMoney-Bitcoin.de-Extension`, `MoneyMoney-Bitget-Extension`, and `MoneyMoney-CoinGecko-Extension`. Both files carry an HTML comment reminding contributors to keep them in sync.
